### PR TITLE
Composer updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,18 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=7.1",
     "ext-soap": "*",
     "ext-SimpleXML": "*",
     "ext-openssl": "*",
     "paragonie/random_compat": ">=1"
   },
   "require-dev": {
-    "phpspec/phpspec": "^2.4"
+    "phpspec/phpspec": ">=5"
   },
   "suggest": {
-        "vlucas/phpdotenv": "Provides loading a .env file for obtaining config variables",
-        "symfony/dotenv": "Provides loading a .env file for obtaining config variables"
+    "vlucas/phpdotenv": "Provides loading a .env file for obtaining config variables",
+    "symfony/dotenv": "Provides loading a .env file for obtaining config variables"
   },
   "autoload": {
     "psr-4": {
@@ -34,6 +34,6 @@
   },
   "minimum-stability": "stable",
   "scripts": {
-      "generate": "php utilities/separate_classes.php"
+    "generate": "php utilities/separate_classes.php"
   }
 }


### PR DESCRIPTION
* Require `php >= 7.1` for the next release (2021.1.0)
* Update phpspec to run the included spec files without errors