### PR TITLE
cleanup .env.example grouping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,7 @@
 ## General Settings
-NETSUITE_ENDPOINT="2019_1"
+NETSUITE_ENDPOINT="2020_2"
 NETSUITE_HOST="https://webservices.netsuite.com"
 NETSUITE_ACCOUNT="MYACCT1"
-NETSUITE_APP_ID="AF44ECC6-6691-400C-85A2-9FD7BFABE36E" # Credential Based Auth
-
-## Credential Based Auth Settings
-NETSUITE_EMAIL="jDoe@netsuite.com"
-NETSUITE_PASSWORD="mySecretPwd"
-NETSUITE_ROLE="1"
 
 ## Token Based Auth Settings
 NETSUITE_HASH_TYPE="sha256"
@@ -17,6 +11,12 @@ NETSUITE_CONSUMER_SECRET=""
 # Access Token Keys
 NETSUITE_TOKEN_KEY=""
 NETSUITE_TOKEN_SECRET=""
+
+## Credential Based Auth Settings (deprecated)
+NETSUITE_EMAIL="jDoe@netsuite.com"
+NETSUITE_PASSWORD="mySecretPwd"
+NETSUITE_APP_ID="AF44ECC6-6691-400C-85A2-9FD7BFABE36E"
+NETSUITE_ROLE="1"
 
 # Logging Options
 #NETSUITE_LOGGING=false


### PR DESCRIPTION
APP_ID is only used with credentials method and that group is now also marked deprecated.