### PR TITLE
Use custom logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ $config = [
     // optional -------------------------------------
     "signatureAlgorithm" => 'sha256', // Defaults to 'sha256'
     "logging"  => true,
-    "log_path" => "/var/www/myapp/logs/netsuite"
+    "log_path" => "/var/www/myapp/logs/netsuite",
+    "logger"   => "Logger", // Custom logger
 ];
 $service = new NetSuiteService($config);
 ```
@@ -89,7 +90,8 @@ $config = [
     "app_id"   => "4AD027CA-88B3-46EC-9D3E-41C6E6A325E2",
     // optional -------------------------------------
     "logging"  => true,
-    "log_path" => "/var/www/myapp/logs/netsuite"
+    "log_path" => "/var/www/myapp/logs/netsuite",
+    "logger"   => "Logger", // Custom logger
 ];
 $service = new NetSuiteService($config);
 ```
@@ -167,6 +169,9 @@ $service->logRequests(true);  // Turn logging on.
 
 // Turn logging off
 $service->logRequests(false); // Turn logging off.
+
+// Use a custom logger - Use Logger.php as sample
+$service->setLogger('MyLogger', '/path/to/logs');
 ```
 
 ## Generating Classes

--- a/src/NetSuiteClient.php
+++ b/src/NetSuiteClient.php
@@ -418,8 +418,8 @@ class NetSuiteClient
 
     /**
      * Set a custom logger
-	 * 
-	 * @param string $logger Name of class
+     * 
+     * @param string $logger Name of class
      * @param string $logPath
      */
     public function setLogger($logger, $logPath) {

--- a/src/NetSuiteClient.php
+++ b/src/NetSuiteClient.php
@@ -63,7 +63,11 @@ class NetSuiteClient
         if (isset($client)) {
           $this->client = $client;
         }
-        $this->logger = new Logger(
+
+        if (!isset($this->config['logger'])) {
+            $this->config['logger'] = 'NetSuite\\Logger';
+        }
+        $this->logger = new $this->config['logger'](
             isset($this->config['log_path']) ? $this->config['log_path'] : NULL
         );
 
@@ -94,7 +98,7 @@ class NetSuiteClient
     public static function getEnvConfig()
     {
         $config = [
-            'endpoint'           => getenv('NETSUITE_ENDPOINT') ?: '2019_1',
+            'endpoint'           => getenv('NETSUITE_ENDPOINT') ?: '2021_1',
             'host'               => getenv('NETSUITE_HOST') ?: 'https://webservices.sandbox.netsuite.com',
             'email'              => getenv('NETSUITE_EMAIL'),
             'password'           => getenv('NETSUITE_PASSWORD'),
@@ -413,6 +417,17 @@ class NetSuiteClient
     }
 
     /**
+     * Set a custom logger
+	 * 
+	 * @param string $logger Name of class
+     * @param string $logPath
+     */
+    public function setLogger($logger, $logPath) {
+        $this->config['log_path'] = $logPath;
+        $this->logger = new $this->config['logger']($logPath);
+    }
+
+    /**
      * Set the logging path.
      *
      * @param string $logPath
@@ -420,7 +435,7 @@ class NetSuiteClient
     public function setLogPath($logPath)
     {
         $this->config['log_path'] = $logPath;
-        $this->logger = new Logger($logPath);
+        $this->logger = new $this->config['logger']($logPath);
     }
 
     /**


### PR DESCRIPTION
The goal here is to add a custom logger. This is necessary for our use case as we want to requests and responses to all be in the same file and we wanted to redact some fields.  To enable this feature, a new config option, _logger_ has been added which will take a string identifying the name of the class. (Note, I considered also allowing `'logger' => new MyLogger($path)` but decided that would make `$this->config['log_path']` inconsistent, so I decided against it. Logger still defaults to the built in logger.