### PR TITLE
fix "Argument #1 ($message) must be of type Stringable|string, null given"

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -102,7 +102,7 @@ class Logger implements LoggerInterface
         );
 
         $this->writeMessage(
-            static::getSoapCallResponseMessage($client),
+            static::getSoapCallResponseMessage($client) ?? '',
             ['operation' => $operation, 'type' => self::TYPE_RESPONSE]
         );
     }

--- a/src/NetSuiteClient.php
+++ b/src/NetSuiteClient.php
@@ -421,12 +421,12 @@ class NetSuiteClient
     {
         if (isset($this->config['logging']) && $this->config['logging']) {
             $this->logger->info(
-                Logger::getSoapCallRequestMessage($this->getClient()),
+                Logger::getSoapCallRequestMessage($this->getClient()) ?? '',
                 ['operation' => $operation, 'type' => Logger::TYPE_REQUEST]
             );
 
             $this->logger->info(
-                Logger::getSoapCallResponseMessage($this->getClient()),
+                Logger::getSoapCallResponseMessage($this->getClient()) ?? '',
                 ['operation' => $operation, 'type' => Logger::TYPE_RESPONSE]
             );
         }


### PR DESCRIPTION
Fix bug:

> TypeError(code: 0): NetSuite\\Logger::info(): Argument #1 ($message) must be of type Stringable|string, null given, called in vendor/ryanwinchester/netsuite-php/src/NetSuiteClient.php on line 428