### PR TITLE
Bump php requirement to >=8 going forward

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.1",
     "ext-soap": "*",
     "ext-SimpleXML": "*",
     "ext-openssl": "*",


### PR DESCRIPTION
As documented, future versions will require PHP >= 8 or greater