### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "ext-soap": "*",
     "ext-SimpleXML": "*",
     "ext-openssl": "*",
-    "paragonie/random_compat": ">=1",
     "psr/log": "^1|^2|^3"
   },
   "require-dev": {


### PR DESCRIPTION
This package depends on `paragonie/random_compat: >=1`, but also `php: >=8.1`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?